### PR TITLE
IObservableのSubscribeをフックできるようにする

### DIFF
--- a/Runtime/Hook.meta
+++ b/Runtime/Hook.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a4a561fe09e44bdb94d9020ba727a29f
+timeCreated: 1684755972

--- a/Runtime/Hook/ObservableExtensions.cs
+++ b/Runtime/Hook/ObservableExtensions.cs
@@ -43,8 +43,8 @@ namespace Extreal.Core.Common.Hook
             {
                 if (Logger.IsDebug())
                 {
-                    // Output the log at the Error level so that the developer is aware of the error during development.
-                    Logger.LogError("Error occurred on hook", e);
+                    // Outputs the log with Error level so that the developer is aware of the error during development.
+                    Logger.LogError("Error has occurred on hook", e);
                 }
             }
         }

--- a/Runtime/Hook/ObservableExtensions.cs
+++ b/Runtime/Hook/ObservableExtensions.cs
@@ -12,32 +12,32 @@ namespace Extreal.Core.Common.Hook
         private static readonly ELogger Logger = LoggingManager.GetLogger(nameof(ObservableExtensions));
 
         /// <summary>
-        /// Hooks the subscription.
+        /// Hooks a notification.
         /// </summary>
         /// <remarks>
-        /// Hook should be implemented in such a way that no exceptions are raised.
-        /// To avoid affecting the processing of Subscribe, if an exception is raised by the hook, nothing is processed.
+        /// The hook must be implemented in such a way that no exception is raised.
+        /// If an exception is raised by the hook, nothing is done because it does not affect the processing of other Subscribers.
         /// </remarks>
         /// <param name="source">Observable</param>
         /// <param name="hook">Processing for hook</param>
         /// <typeparam name="T">Type of value to be notified</typeparam>
         /// <returns>Observable</returns>
         /// <exception cref="ArgumentNullException">If hook is null</exception>
-        public static IObservable<T> Hook<T>(this IObservable<T> source, Action<T> hook)
+        public static IDisposable Hook<T>(this IObservable<T> source, Action<T> hook)
         {
             if (hook == null)
             {
                 throw new ArgumentNullException(nameof(hook));
             }
 
-            return source.Do(obj => InvokeHookSafely(hook, obj));
+            return source.Subscribe(value => InvokeHookSafely(hook, value));
         }
 
-        private static void InvokeHookSafely<T>(Action<T> hook, T obj)
+        private static void InvokeHookSafely<T>(Action<T> hook, T value)
         {
             try
             {
-                hook.Invoke(obj);
+                hook.Invoke(value);
             }
             catch (Exception e)
             {

--- a/Runtime/Hook/ObservableExtensions.cs
+++ b/Runtime/Hook/ObservableExtensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Extreal.Core.Logging;
+using UniRx;
+
+namespace Extreal.Core.Common.Hook
+{
+    /// <summary>
+    /// Class for extending Observable.
+    /// </summary>
+    public static class ObservableExtensions
+    {
+        private static readonly ELogger Logger = LoggingManager.GetLogger(nameof(ObservableExtensions));
+
+        /// <summary>
+        /// Hooks the subscription.
+        /// </summary>
+        /// <remarks>
+        /// Hook should be implemented in such a way that no exceptions are raised.
+        /// To avoid affecting the processing of Subscribe, if an exception is raised by the hook, nothing is processed.
+        /// </remarks>
+        /// <param name="source">Observable</param>
+        /// <param name="hook">Processing for hook</param>
+        /// <typeparam name="T">Type of value to be notified</typeparam>
+        /// <returns>Observable</returns>
+        /// <exception cref="ArgumentNullException">If hook is null</exception>
+        public static IObservable<T> Hook<T>(this IObservable<T> source, Action<T> hook)
+        {
+            if (hook == null)
+            {
+                throw new ArgumentNullException(nameof(hook));
+            }
+
+            return source.Do(obj => InvokeHookSafely(hook, obj));
+        }
+
+        private static void InvokeHookSafely<T>(Action<T> hook, T obj)
+        {
+            try
+            {
+                hook.Invoke(obj);
+            }
+            catch (Exception e)
+            {
+                if (Logger.IsDebug())
+                {
+                    Logger.LogDebug("Error occurred on hook", e);
+                }
+            }
+        }
+    }
+}

--- a/Runtime/Hook/ObservableExtensions.cs
+++ b/Runtime/Hook/ObservableExtensions.cs
@@ -43,7 +43,8 @@ namespace Extreal.Core.Common.Hook
             {
                 if (Logger.IsDebug())
                 {
-                    Logger.LogDebug("Error occurred on hook", e);
+                    // Output the log at the Error level so that the developer is aware of the error during development.
+                    Logger.LogError("Error occurred on hook", e);
                 }
             }
         }

--- a/Runtime/Hook/ObservableExtensions.cs.meta
+++ b/Runtime/Hook/ObservableExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 235e9ecf426648288944e8aaeb497926
+timeCreated: 1684755982

--- a/Tests/Runtime/Hook.meta
+++ b/Tests/Runtime/Hook.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b4eb5cb436374886943cee34f938c947
+timeCreated: 1684757030

--- a/Tests/Runtime/Hook/ObservableExtensionsTest.cs
+++ b/Tests/Runtime/Hook/ObservableExtensionsTest.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using Extreal.Core.Common.Hook;
+using Extreal.Core.Logging;
+using NUnit.Framework;
+using UniRx;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Extreal.Core.Common.Test.Tests.Runtime.Hook
+{
+    public class ObservableExtensionsTest
+    {
+        [OneTimeSetUp]
+        public void OneTimeSetUp() => LoggingManager.Initialize(logLevel: LogLevel.Debug);
+
+        private CompositeDisposable disposables;
+
+        [SetUp]
+        public void SetUp() => disposables = new CompositeDisposable();
+
+        [TearDown]
+        public void TearDown() => disposables.Dispose();
+
+        [Test]
+        public void HookIsNull() =>
+            Assert.That(() =>
+                {
+                    var point = new ReactiveProperty<int>(0).AddTo(disposables);
+                    point.Hook(null);
+                },
+                Throws.TypeOf<ArgumentNullException>().With.Message.Contain("Parameter name: hook"));
+
+        [Test]
+        public void Hook()
+        {
+            var total = 0;
+            var hookTotal = 0;
+
+            var point = new ReactiveProperty<int>(0).AddTo(disposables);
+            Action<int> onNext = i => total += i;
+            Action<int> hook = _ => hookTotal += 1;
+            point.Hook(hook).Subscribe(onNext).AddTo(disposables);
+
+            point.Value = 1;
+            point.Value = 2;
+            point.Value = 3;
+
+            Assert.That(total, Is.EqualTo(6));
+            Assert.That(hookTotal, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void ExceptionOccurredOnHook()
+        {
+            LogAssert.Expect(LogType.Log, new Regex(".*Error occurred on hook.*"));
+
+            var total = 0;
+
+            var point = new ReactiveProperty<int>(0).AddTo(disposables);
+            Action<int> onNext = i => total += i;
+            Action<int> hook = _ => throw new Exception("HOOK ERROR");
+            point.Hook(hook).Subscribe(onNext).AddTo(disposables);
+
+            point.Value = 1;
+            point.Value = 2;
+            point.Value = 3;
+
+            Assert.That(total, Is.EqualTo(6));
+        }
+    }
+}

--- a/Tests/Runtime/Hook/ObservableExtensionsTest.cs
+++ b/Tests/Runtime/Hook/ObservableExtensionsTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text.RegularExpressions;
-using Extreal.Core.Common.Hook;
 using Extreal.Core.Logging;
 using NUnit.Framework;
 using UniRx;
@@ -51,7 +50,7 @@ namespace Extreal.Core.Common.Hook.Test
         public void ExceptionOccurredOnHook()
         {
             LogAssert.ignoreFailingMessages = true;
-            LogAssert.Expect(LogType.Error, new Regex(".*Error occurred on hook.*"));
+            LogAssert.Expect(LogType.Error, new Regex(".*Error has occurred on hook.*"));
 
             var total = 0;
 

--- a/Tests/Runtime/Hook/ObservableExtensionsTest.cs
+++ b/Tests/Runtime/Hook/ObservableExtensionsTest.cs
@@ -7,7 +7,7 @@ using UniRx;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-namespace Extreal.Core.Common.Test.Tests.Runtime.Hook
+namespace Extreal.Core.Common.Hook.Test
 {
     public class ObservableExtensionsTest
     {
@@ -50,7 +50,8 @@ namespace Extreal.Core.Common.Test.Tests.Runtime.Hook
         [Test]
         public void ExceptionOccurredOnHook()
         {
-            LogAssert.Expect(LogType.Log, new Regex(".*Error occurred on hook.*"));
+            LogAssert.ignoreFailingMessages = true;
+            LogAssert.Expect(LogType.Error, new Regex(".*Error occurred on hook.*"));
 
             var total = 0;
 

--- a/Tests/Runtime/Hook/ObservableExtensionsTest.cs
+++ b/Tests/Runtime/Hook/ObservableExtensionsTest.cs
@@ -35,19 +35,16 @@ namespace Extreal.Core.Common.Test.Tests.Runtime.Hook
         public void Hook()
         {
             var total = 0;
-            var hookTotal = 0;
 
             var point = new ReactiveProperty<int>(0).AddTo(disposables);
-            Action<int> onNext = i => total += i;
-            Action<int> hook = _ => hookTotal += 1;
-            point.Hook(hook).Subscribe(onNext).AddTo(disposables);
+            Action<int> hook = value => total += value;
+            point.Hook(hook).AddTo(disposables);
 
             point.Value = 1;
             point.Value = 2;
             point.Value = 3;
 
             Assert.That(total, Is.EqualTo(6));
-            Assert.That(hookTotal, Is.EqualTo(4));
         }
 
         [Test]
@@ -58,9 +55,10 @@ namespace Extreal.Core.Common.Test.Tests.Runtime.Hook
             var total = 0;
 
             var point = new ReactiveProperty<int>(0).AddTo(disposables);
-            Action<int> onNext = i => total += i;
+            Action<int> onNext = value => total += value;
             Action<int> hook = _ => throw new Exception("HOOK ERROR");
-            point.Hook(hook).Subscribe(onNext).AddTo(disposables);
+            point.Subscribe(onNext).AddTo(disposables);
+            point.Hook(hook).AddTo(disposables);
 
             point.Value = 1;
             point.Value = 2;

--- a/Tests/Runtime/Hook/ObservableExtensionsTest.cs.meta
+++ b/Tests/Runtime/Hook/ObservableExtensionsTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 45d36e000a754990903628772cb0a4d3
+timeCreated: 1684757044

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "jp.co.tis.extreal.core.common",
-  "version": "1.0.0",
+  "version": "1.1.0-next.1",
   "displayName": "Extreal.Core.Common",
   "unity": "2021.3",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "jp.co.tis.extreal.core.common",
-  "version": "1.1.0-next.1",
+  "version": "1.1.0-next.2",
   "displayName": "Extreal.Core.Common",
   "unity": "2021.3",
   "author": {


### PR DESCRIPTION
# 何の変更を加えましたか？

- ユーザ操作イベントのログ収集をできるように、IObservableのSubscribeをフックできる機能をIObservableに追加しました。
- ReactiveProperyやSubjectのラッパを作ってイベント通知側で実現することを検討しましたが、次の理由によりSubscribe側でログ収集を入れる想定にしました。
  - ログ収集に必要なデータ加工やどのイベントを送るのかはアプリ要件に依存して決まるため。
    - アプリで共通利用できるHookを用意しておき、送りたいイベントにHookを入れていくイメージです。
    - 個別にイベントを入れる手間はありますが宣言的に入れられるので実装負荷は少ない方だと思います。
  - イベント通知側が通知したイベントをどう使うのかを意識するのが役割として不自然
- 今回追加したHookメソッドはUniRxのSubscribeメソッドと似ていますが、他のSubscribeの処理に影響を与えないように、フックで例外が発生しても何もしない点が異なります。

# 何を確認しましたか?

## 実装

- [x] Frameworkの誤った使い方にすぐに気づけるように、無効な引数や無効なメソッド呼び出しに対するチェックが入っていることを確認しました
- [x] Framework実行時の動きが分かるように、ログ（Error/Warn/Info/Debug）を出力していることを確認しました
- [x] 静的解析で問題が見つからないことを確認しました
- [x] フレームワーク利用者が使うAPI（主にprivate以外）に C# ドキュメントを記述しました

## テスト

- [x] 全ての自動テストが成功することを確認しました
- [x] テストカバレッジが100%になることを確認しました
- [x] サンプルがあるものはサンプルが動作することを確認しました
  - サンプルなし

## 変更影響

- [x] GuideのReleaseページに変更内容が追加されることを確認しました
- [x] GuideのModuleページ（機能ページ）に変更が反映されることを確認しました
  - https://github.com/extreal-dev/Extreal.Guide/pull/46
- [x] GuideのLearningページに変更が反映されることを確認しました
  - Holidayに反映するのみのため不要
- [x] Sample Applicationに変更が反映されることを確認しました
  - https://github.com/extreal-dev/Extreal.SampleApp.Holiday/pull/8 

# レビュアーへのメッセージ

- CommonにHook機能を追加してHolidayのアプリ利用状況可視化で使用しました。
